### PR TITLE
Add uninstall support for portletmanagers introduced in 3dfe602

### DIFF
--- a/Products/ContentWellPortlets/profiles/uninstall/portlets.xml
+++ b/Products/ContentWellPortlets/profiles/uninstall/portlets.xml
@@ -118,4 +118,36 @@
          name="ContentWellPortlets.FooterPortletManager6"
          type="Products.ContentWellPortlets.browser.interfaces.IFooterPortlets"
     />
+
+    <portletmanager remove="True"
+         name="ContentWellPortlets.BelowTitlePortletManager1"
+         type="Products.ContentWellPortlets.browser.interfaces.IPortletsBelowContentTitle"
+    />
+
+    <portletmanager remove="True"
+         name="ContentWellPortlets.BelowTitlePortletManager2"
+         type="Products.ContentWellPortlets.browser.interfaces.IPortletsBelowContentTitle"
+    />
+
+    <portletmanager remove="True"
+         name="ContentWellPortlets.BelowTitlePortletManager3"
+         type="Products.ContentWellPortlets.browser.interfaces.IPortletsBelowContentTitle"
+    />
+
+    <portletmanager remove="True"
+         name="ContentWellPortlets.BelowTitlePortletManager4"
+         type="Products.ContentWellPortlets.browser.interfaces.IPortletsBelowContentTitle"
+    />
+
+    <portletmanager remove="True"
+         name="ContentWellPortlets.BelowTitlePortletManager5"
+         type="Products.ContentWellPortlets.browser.interfaces.IPortletsBelowContentTitle"
+    />
+
+    <portletmanager remove="True"
+         name="ContentWellPortlets.BelowTitlePortletManager6"
+         type="Products.ContentWellPortlets.browser.interfaces.IPortletsBelowContentTitle"
+    />
+
+    
 </portlets>


### PR DESCRIPTION
This makes ContentWellPortlets cleanly uninstallable again, fixing a hole in the uninstall that opened up with 3dfe602